### PR TITLE
Use sqlalchemy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Processing GoC-Spending data output
 
 - Python 3.6
 - [MySQL](https://dev.mysql.com/downloads/cluster/)
-- [Protobuf](https://github.com/google/protobuf/)
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ requests==2.18.4
 pandas==0.20.3
 pylint==1.7.2
 mypy==0.521
-mysql-connector==2.2.3
 pytest==3.2.2
+sqlalchemy==1.1.14
+mysqlclient==1.3.12

--- a/script/build_container.sh
+++ b/script/build_container.sh
@@ -2,7 +2,7 @@
 set -ex
 
 apt-get update
-apt-get install -y libprotobuf-dev protobuf-compiler software-properties-common python-software-properties python3-pip
+apt-get install -y software-properties-common python-software-properties python3-pip
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update && apt-get install -y python3.6 python3.6-dev
 

--- a/script/build_container.sh
+++ b/script/build_container.sh
@@ -7,7 +7,7 @@ add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update && apt-get install -y python3.6 python3.6-dev
 
 export DEBIAN_FRONTEND=noninteractive
-apt-get install -y mysql-server-5.7
+apt-get install -y mysql-server-5.7 libmysqlclient-dev
 mkdir -p /var/lib/mysql
 mkdir -p /var/run/mysqld
 mkdir -p /var/log/mysql

--- a/src/tribble/cli.py
+++ b/src/tribble/cli.py
@@ -37,7 +37,4 @@ def database(ctx: click.core.Context, host: str, user: str, password: typing.Opt
 @click.option('--force', type=bool, default=False, is_flag=True)
 @click.pass_context
 def init(ctx: click.core.Context, force: bool) -> None:
-    with tribble.database.cursor(ctx.obj['creds']) as cursor:
-        if force:
-            tribble.database.drop_table(cursor)
-        tribble.database.create_table(cursor)
+    tribble.database.init(ctx.obj['creds'], force)

--- a/src/tribble/cli.py
+++ b/src/tribble/cli.py
@@ -6,6 +6,9 @@ import tribble.database
 import tribble.transform
 
 
+SPENDING_DB_NAME = 'spending'
+
+
 @click.group()
 @click.pass_context
 def main(ctx: click.core.Context) -> None:
@@ -26,7 +29,7 @@ def transform(input_dir: str, output: str) -> None:
 @click.option('--host', default='localhost')
 @click.option('--user', default=getpass.getuser())
 @click.option('--password')
-@click.option('--schema', default='spending')
+@click.option('--schema', default=SPENDING_DB_NAME)
 @click.pass_context
 def database(ctx: click.core.Context, host: str, user: str, password: typing.Optional[str], schema: str) -> None:
     creds = tribble.database.Creds(host, user, password, schema)
@@ -34,7 +37,21 @@ def database(ctx: click.core.Context, host: str, user: str, password: typing.Opt
 
 
 @database.command()
+@click.option('--runtime-user', default=getpass.getuser())
+@click.option('--runtime-host', default='localhost')
+@click.option('--force', type=bool, default=False, is_flag=True)
+@click.pass_context
+def create(ctx: click.core.Context, runtime_user: str, runtime_host: str, force: bool) -> None:
+    passed_creds = ctx.obj['creds']
+    creds = tribble.database.Creds(host=passed_creds.host, user=passed_creds.user,
+                                   password=passed_creds.password, database='mysql')
+    engine = tribble.database.connect_db(creds)
+    tribble.database.create_db(engine, passed_creds.database, runtime_user, runtime_host, force)
+
+
+@database.command()
 @click.option('--force', type=bool, default=False, is_flag=True)
 @click.pass_context
 def init(ctx: click.core.Context, force: bool) -> None:
-    tribble.database.init(ctx.obj['creds'], force)
+    engine = tribble.database.connect_db(ctx.obj['creds'])
+    tribble.database.init(engine, force)

--- a/src/tribble/database.py
+++ b/src/tribble/database.py
@@ -1,5 +1,5 @@
 import typing
-from sqlalchemy import create_engine, MetaData, Table, Column, VARCHAR, TEXT
+from sqlalchemy import create_engine, MetaData, Table, Column, VARCHAR, TEXT, engine
 
 
 class Creds(typing.NamedTuple):
@@ -9,24 +9,38 @@ class Creds(typing.NamedTuple):
     database: str
 
 
-def init(creds: Creds, force: bool) -> None:
+def connect_db(creds: Creds) -> engine.base.Engine:
     password_stub = f':{creds.password}' if creds.password else ''
-    engine = create_engine(f"mysql+mysqldb://{creds.user}{password_stub}@{creds.host}/{creds.database}")
+    return create_engine(f"mysql+mysqldb://{creds.user}{password_stub}@{creds.host}/{creds.database}")
+
+
+def create_db(engine: engine.base.Engine, database_name: str, runtime_user: str, runtime_host: str,
+              force: bool = False) -> None:
+    connection = engine.connect()
+    if force:
+        connection.execute(f'DROP SCHEMA IF EXISTS {database_name};')
+    connection.execute(f'CREATE SCHEMA {database_name};')
+    connection.execute(f'GRANT ALL PRIVILEGES ON {database_name}.* to {runtime_user}@{runtime_host};')
+    connection.execute('FLUSH PRIVILEGES;')
+    connection.close()
+
+
+def init(engine: engine.base.Engine, force: bool) -> None:
     meta = MetaData(bind=engine)
 
-    spending = Table('spending', meta,
-                     Column('uuid', VARCHAR(length=255), primary_key=True, autoincrement=False),
-                     Column('vendor_name', TEXT, nullable=True),
-                     Column('reference_number', TEXT, nullable=True),
-                     Column('contract_date', VARCHAR(length=255), nullable=True),
-                     Column('contract_period_start', VARCHAR(length=255), nullable=True),
-                     Column('contract_period_end', VARCHAR(length=255), nullable=True),
-                     Column('delivery_date', VARCHAR(length=255), nullable=True),
-                     Column('contract_value', VARCHAR(length=255), nullable=True),
-                     Column('department', TEXT, nullable=True),
-                     Column('source_fiscal', VARCHAR(length=255), nullable=True)
-                    )
+    contracts = Table('contracts', meta,
+                      Column('uuid', VARCHAR(length=255), primary_key=True, autoincrement=False),
+                      Column('vendor_name', TEXT, nullable=True),
+                      Column('reference_number', TEXT, nullable=True),
+                      Column('contract_date', VARCHAR(length=255), nullable=True),
+                      Column('contract_period_start', VARCHAR(length=255), nullable=True),
+                      Column('contract_period_end', VARCHAR(length=255), nullable=True),
+                      Column('delivery_date', VARCHAR(length=255), nullable=True),
+                      Column('contract_value', VARCHAR(length=255), nullable=True),
+                      Column('department', TEXT, nullable=True),
+                      Column('source_fiscal', VARCHAR(length=255), nullable=True)
+                     )
 
-    if force:
-        spending.drop(engine)
-    spending.create(engine)
+    if force and contracts.exists():
+        contracts.drop(engine)
+    contracts.create(engine)

--- a/src/tribble/database.py
+++ b/src/tribble/database.py
@@ -1,8 +1,5 @@
-import contextlib
 import typing
-import mysql.connector
-from mysql.connector import cursor as mysql_cursor
-from mysql.connector import errorcode
+from sqlalchemy import create_engine, MetaData, Table, Column, VARCHAR, TEXT
 
 
 class Creds(typing.NamedTuple):
@@ -12,45 +9,24 @@ class Creds(typing.NamedTuple):
     database: str
 
 
-@contextlib.contextmanager
-def cursor(creds: Creds) -> mysql_cursor.MySQLCursor:
-    connection: typing.Optional[mysql.connector.MySQLConnection] = None
-    cursor_ = None
-    try:
-        connection = mysql.connector.connect(**creds._asdict())
-    except mysql.connector.Error as err:
-        if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
-            print("Access Denied. Check your username and password.")
-        elif err.errno == errorcode.ER_BAD_DB_ERROR:
-            print("Database {} does not exist".format(creds.database))
-        else:
-            print("Unknown error: {}".format(err.msg))
-    else:
-        cursor_ = connection.cursor()
-        yield cursor_
-    finally:
-        if cursor_:
-            cursor_.close()
-        if connection:
-            connection.close()
+def init(creds: Creds, force: bool) -> None:
+    password_stub = f':{creds.password}' if creds.password else ''
+    engine = create_engine(f"mysql+mysqldb://{creds.user}{password_stub}@{creds.host}/{creds.database}")
+    meta = MetaData(bind=engine)
 
+    spending = Table('spending', meta,
+                     Column('uuid', VARCHAR(length=255), primary_key=True, autoincrement=False),
+                     Column('vendor_name', TEXT, nullable=True),
+                     Column('reference_number', TEXT, nullable=True),
+                     Column('contract_date', VARCHAR(length=255), nullable=True),
+                     Column('contract_period_start', VARCHAR(length=255), nullable=True),
+                     Column('contract_period_end', VARCHAR(length=255), nullable=True),
+                     Column('delivery_date', VARCHAR(length=255), nullable=True),
+                     Column('contract_value', VARCHAR(length=255), nullable=True),
+                     Column('department', TEXT, nullable=True),
+                     Column('source_fiscal', VARCHAR(length=255), nullable=True)
+                    )
 
-def create_table(cursor_: mysql_cursor.MySQLCursor) -> None:
-    cursor_.execute(
-        "CREATE TABLE contracts ("
-        "  uuid VARCHAR(50), "
-        "  vendor_name VARCHAR(255), "
-        "  reference_number VARCHAR(255), "
-        "  contract_date VARCHAR(20), "
-        "  contract_period_start VARCHAR(20), "
-        "  contract_period_end VARCHAR(20), "
-        "  delivery_date VARCHAR(20), "
-        "  contract_value VARCHAR(255), "
-        "  department VARCHAR(20), "
-        "  source_fiscal VARCHAR(20)"
-        ");"
-    )
-
-
-def drop_table(cursor_: mysql_cursor.MySQLCursor) -> None:
-    cursor_.execute('DROP TABLE IF EXISTS contracts;')
+    if force:
+        spending.drop(engine)
+    spending.create(engine)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,7 @@
 from sqlalchemy import engine
 from tribble import database
 
+
 def test_connection(db_engine: engine.base.Engine) -> None:
     connection = db_engine.connect()
     result = connection.execute('SELECT 1;').fetchall()
@@ -8,4 +9,10 @@ def test_connection(db_engine: engine.base.Engine) -> None:
 
 
 def test_init(db_engine: engine.base.Engine) -> None:
+    connection = db_engine.connect()
+    result = connection.execute("SHOW TABLES LIKE 'contracts';").fetchall()
+    assert not result
+
     database.init(db_engine, force=True)
+    result = connection.execute("SHOW TABLES LIKE 'contracts';").fetchall()
+    assert len(result) == 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,10 +1,11 @@
-import typing
-import mysql.connector
+from sqlalchemy import engine
+from tribble import database
+
+def test_connection(db_engine: engine.base.Engine) -> None:
+    connection = db_engine.connect()
+    result = connection.execute('SELECT 1;').fetchall()
+    assert result == [(1,)]
 
 
-def test_connection(db_host: str, db_user: str, db_password: typing.Optional[str], db_name: str):
-    connection = mysql.connector.connect(host=db_host, user=db_user, password=db_password, database=db_name)
-    cursor = connection.cursor()
-
-    cursor.execute('SELECT 1;')
-    assert list(cursor) == [(1,)]
+def test_init(db_engine: engine.base.Engine) -> None:
+    database.init(db_engine, force=True)


### PR DESCRIPTION
This PR switches the connection to use SQLAlchemy instead of a bespoke Python connector, which requires Protobuf to be available locally.

Also adds the ability to create the database, and to initialize the table in the database.
