### PR TITLE
add raw_contracts data model

### DIFF
--- a/src/tribble/cli.py
+++ b/src/tribble/cli.py
@@ -5,6 +5,7 @@ import tribble.database
 import tribble.transform
 from tribble import contract
 from tribble import loader
+from tribble import reader
 
 
 SPENDING_DB_NAME = 'spending'
@@ -51,5 +52,8 @@ def init_db(ctx: click.core.Context, force: bool) -> None:
 @main.command()
 @click.argument('input-dir')
 def load(input_dir: str) -> None:
-    df = tribble.transform.transform_dir(input_dir)
-    loader.load_dataframe(df)
+    raw_contracts = reader.read_dir(input_dir)
+    contracts = tribble.transform.transform(raw_contracts)
+
+    loader.load_dataframe(raw_contracts, contract.RawContract)
+    loader.load_dataframe(contracts, contract.Contract)

--- a/src/tribble/contract.py
+++ b/src/tribble/contract.py
@@ -33,3 +33,19 @@ class Contract(Base):  # type: ignore
             return False
         return all([getattr(self, key) == getattr(other, key)
                     for key in self.metadata.tables[self.__tablename__].columns.keys()])
+
+
+class RawContract(Base):  # type: ignore
+    __tablename__ = 'raw_contracts'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    uuid = Column(String(255))
+    vendorName = Column(TEXT, nullable=True)
+    referenceNumber = Column(TEXT, nullable=True)
+    contractDate = Column(TEXT, nullable=True)
+    contractPeriodStart = Column(TEXT, nullable=True)
+    contractPeriodEnd = Column(TEXT, nullable=True)
+    contractValue = Column(String(255), nullable=True)
+    ownerAcronym = Column(TEXT, nullable=True)
+    sourceFiscal = Column(TEXT, nullable=True)
+    objectCode = Column(TEXT, nullable=True)

--- a/src/tribble/loader.py
+++ b/src/tribble/loader.py
@@ -2,9 +2,9 @@ import pandas
 from tribble import contract
 
 
-def load_dataframe(df: pandas.DataFrame) -> None:
+def load_dataframe(df: pandas.DataFrame, model: contract.Base) -> None:
     data = df.to_dict('records')
 
     session = contract.Session()
-    session.bulk_insert_mappings(contract.Contract, data)
+    session.bulk_insert_mappings(model, data)
     session.commit()

--- a/src/tribble/reader.py
+++ b/src/tribble/reader.py
@@ -1,0 +1,34 @@
+import itertools
+import json
+import os
+import typing
+import pandas as pd
+
+
+T = typing.TypeVar('T')
+
+
+def _json_blobs(input_dir: str) -> typing.Iterator[typing.Dict[str, typing.Any]]:
+    input_filenames = [os.path.join(input_dir, dir_name) for dir_name in os.listdir(input_dir)]
+
+    for filename in input_filenames:
+        with open(filename) as input_file:
+            yield json.loads(input_file.read())
+
+
+def _grouper(iterable: typing.Iterable[T], group_length: int) -> typing.Iterable[T]:
+    """Collect data into fixed-length chunks or blocks"""
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
+    args = [iter(iterable)] * group_length
+    return itertools.zip_longest(*args, fillvalue=None)
+
+
+def read_dir(input_dir: str, grouping_length: int = 100) -> pd.DataFrame:
+    df: typing.Optional[pd.DataFrame] = None
+
+    blobs = _json_blobs(input_dir)
+    for group in _grouper(blobs, grouping_length):
+        chunk = [x for x in group if x]
+        df = pd.DataFrame(chunk) if df is None else df.append(chunk)
+
+    return df if df is not None else pd.DataFrame()

--- a/src/tribble/transform.py
+++ b/src/tribble/transform.py
@@ -1,7 +1,3 @@
-import itertools
-import json
-import os
-import typing
 import pandas
 from tribble.transformers import clear_blanks
 from tribble.transformers import contract_date_cleaner
@@ -9,35 +5,6 @@ from tribble.transformers import date_parser
 from tribble.transformers import fiscal_date_converter
 from tribble.transformers import reporting_periodizer
 from tribble.transformers import schema_conformer
-
-
-def transform_dir(input_dir: str, grouping_length: int = 100) -> pandas.DataFrame:
-    df: typing.Optional[pandas.DataFrame] = None
-
-    blobs = _json_blobs(input_dir)
-    for group in _grouper(blobs, grouping_length):
-        chunk = [x for x in group if x]
-        df = pandas.DataFrame(chunk) if df is None else df.append(chunk)
-
-    return transform(df) if df is not None else pandas.DataFrame()
-
-
-T = typing.TypeVar('T')
-
-
-def _grouper(iterable: typing.Iterable[T], group_length: int) -> typing.Iterable[T]:
-    """Collect data into fixed-length chunks or blocks"""
-    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
-    args = [iter(iterable)] * group_length
-    return itertools.zip_longest(*args, fillvalue=None)
-
-
-def _json_blobs(input_dir: str) -> typing.Iterator[typing.Dict[str, typing.Any]]:
-    input_filenames = [os.path.join(input_dir, dir_name) for dir_name in os.listdir(input_dir)]
-
-    for filename in input_filenames:
-        with open(filename) as input_file:
-            yield json.loads(input_file.read())
 
 
 def transform(df: pandas.DataFrame) -> pandas.DataFrame:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,10 +56,13 @@ def test_load(input_dir: py._path.local.LocalPath) -> None:
 
     session = contract.Session()
     contracts = list(session.query(contract.Contract))
+    raw_contracts = list(session.query(contract.Contract))
     session.close()
 
     assert len(contracts) == 1
     assert contracts[0].uuid == 'tbs-0000000000'
+    assert len(raw_contracts) == 1
+    assert raw_contracts[0].uuid == 'tbs-0000000000'
 
 
 def test_init_db(db_engine: engine.base.Engine) -> None:
@@ -74,13 +77,18 @@ def test_init_db(db_engine: engine.base.Engine) -> None:
 
     tables = connection.execute("SHOW TABLES LIKE 'contracts';").fetchall()
     assert len(tables) == 1
+    raw_tables = connection.execute("SHOW TABLES LIKE 'contracts';").fetchall()
+    assert len(raw_tables) == 1
 
 
 def test_init_db_with_force(db_engine: engine.base.Engine) -> None:
     connection = db_engine.connect()
     connection.execute("CREATE TABLE contracts (foo INT NOT NULL)")
+    connection.execute("CREATE TABLE raw_contracts (foo INT NOT NULL)")
     table_def = connection.execute("SHOW CREATE TABLE contracts;").fetchall()[0][1]
     assert 'foo' in table_def
+    raw_table_def = connection.execute("SHOW CREATE TABLE raw_contracts;").fetchall()[0][1]
+    assert 'foo' in raw_table_def
 
     runner = click.testing.CliRunner()  # type: ignore
     result = runner.invoke(cli.init_db, ['--force'], obj={'engine': db_engine})
@@ -90,3 +98,6 @@ def test_init_db_with_force(db_engine: engine.base.Engine) -> None:
     table_def = connection.execute("SHOW CREATE TABLE contracts;").fetchall()[0][1]
     assert 'foo' not in table_def
     assert 'uuid' in table_def
+    raw_table_def = connection.execute("SHOW CREATE TABLE raw_contracts;").fetchall()[0][1]
+    assert 'foo' not in raw_table_def
+    assert 'uuid' in raw_table_def

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,6 +2,7 @@ import datetime
 import typing
 import pandas
 import pytest
+from tribble import contract
 from tribble import loader
 
 
@@ -22,4 +23,4 @@ def test_load_dataframe() -> None:
     data = [row1, row2]
     df = pandas.DataFrame(data)
 
-    loader.load_dataframe(df)
+    loader.load_dataframe(df, contract.Contract)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,18 @@
+import json
+import py
+from tribble import reader
+
+
+def test_chunking(tmpdir: py._path.local.LocalPath) -> None:
+    for i in range(0, 100):
+        data = {'uuid': 'tbs-{}'.format(i)}
+        data_file = tmpdir.join('data{}.json'.format(i))
+        data_file.write(json.dumps(data))
+
+    output = reader.read_dir(str(tmpdir), grouping_length=7)
+    assert len(output) == 100
+
+
+def test_blank_dir(tmpdir: py._path.local.LocalPath) -> None:
+    output = reader.read_dir(str(tmpdir))
+    assert len(output) == 0  # pylint: disable=len-as-condition

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,8 +1,6 @@
 import datetime
-import json
 import typing
 import pandas
-import py._path.local
 from tribble import transform
 
 
@@ -58,42 +56,6 @@ def output_template(overrides: typing.Dict[str, typing.Any]) -> typing.Dict[str,
     }
     data.update(overrides)
     return data
-
-
-def test_transform_dir(tmpdir: py._path.local.LocalPath) -> None:
-    data1_file = tmpdir.join('data1.json')
-    data1 = data_template({
-        "uuid": "tbs-0000000000",
-        "vendorName": "ABC Company",
-        "referenceNumber": "0000000000",
-    })
-    data1_file.write(json.dumps(data1))
-
-    data2_file = tmpdir.join('data2.json')
-    data2 = data_template({
-        "uuid": "tbs-0000000001",
-        "vendorName": "XYZ Company",
-        "referenceNumber": "0000000001",
-    })
-    data2_file.write(json.dumps(data2))
-
-    output = transform.transform_dir(str(tmpdir))
-    assert len(output) == 2
-
-
-def test_chunking(tmpdir: py._path.local.LocalPath) -> None:
-    for i in range(0, 100):
-        data = data_template({'uuid': 'tbs-{}'.format(i)})
-        data_file = tmpdir.join('data{}.json'.format(i))
-        data_file.write(json.dumps(data))
-
-    output = transform.transform_dir(str(tmpdir), grouping_length=7)
-    assert len(output) == 100
-
-
-def test_blank_dir(tmpdir: py._path.local.LocalPath) -> None:
-    output = transform.transform_dir(str(tmpdir))
-    assert len(output) == 0  # pylint: disable=len-as-condition
 
 
 def test_transform() -> None:


### PR DESCRIPTION
Adds new `BaseContract` model to assist with model cleanup efforts. `BaseContract` consists of raw, untransformed data.

Refactor transform_dir into separate reader, transformer, loader sections, to allow directory to be read one time, loaded twice (once raw, once transformed).