### PR TITLE
moving contracts backwards in time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==6.7
 lxml==4.0.0
 requests==2.18.4
 pandas==0.20.3
-pylint==1.7.2
+pylint==1.7.3
 mypy==0.521
 pytest==3.2.2
 sqlalchemy==1.1.14

--- a/src/tribble/transform.py
+++ b/src/tribble/transform.py
@@ -1,4 +1,5 @@
 import pandas
+import pandas.core.groupby
 from tribble.transformers import clear_blanks
 from tribble.transformers import contract_date_cleaner
 from tribble.transformers import date_parser
@@ -8,11 +9,19 @@ from tribble.transformers import schema_conformer
 
 
 def transform(df: pandas.DataFrame) -> pandas.DataFrame:
-    return (
+    df = (
         df.pipe(schema_conformer.SchemaConformer().apply)
         .pipe(date_parser.DateParser().apply)
         .pipe(fiscal_date_converter.FiscalDateConverter().apply)
         .pipe(contract_date_cleaner.ContractDateCleaner().apply)
         .pipe(clear_blanks.ClearBlanks().apply)
-        .pipe(reporting_periodizer.ReportingPeriodizer().apply)
+    )
+    return df.groupby('uuid').apply(_group_transform)
+
+
+def _group_transform(df: pandas.DataFrame) -> pandas.DataFrame:
+    df = df.sort_values(['contract_period_start', 'source_fiscal'])
+
+    return (
+        df.pipe(reporting_periodizer.ReportingPeriodizer().apply)
     )

--- a/src/tribble/transform.py
+++ b/src/tribble/transform.py
@@ -2,6 +2,7 @@ import pandas
 import pandas.core.groupby
 from tribble.transformers import clear_blanks
 from tribble.transformers import contract_date_cleaner
+from tribble.transformers import contract_start_normalizer
 from tribble.transformers import date_parser
 from tribble.transformers import fiscal_date_converter
 from tribble.transformers import reporting_periodizer
@@ -23,5 +24,6 @@ def _group_transform(df: pandas.DataFrame) -> pandas.DataFrame:
     df = df.sort_values(['contract_period_start', 'source_fiscal'])
 
     return (
-        df.pipe(reporting_periodizer.ReportingPeriodizer().apply)
+        df.pipe(contract_start_normalizer.ContractStartNormalizer().apply)
+        .pipe(reporting_periodizer.ReportingPeriodizer().apply)
     )

--- a/src/tribble/transformers/contract_start_normalizer.py
+++ b/src/tribble/transformers/contract_start_normalizer.py
@@ -1,0 +1,9 @@
+import pandas as pd
+import numpy as np
+from tribble.transformers import base
+
+
+class ContractStartNormalizer(base.BaseTransform):
+    def apply(self, data: pd.DataFrame) -> pd.DataFrame:
+        data['contract_period_start'] = np.min(data['contract_period_start'])
+        return data

--- a/src/tribble/transformers/reporting_periodizer.py
+++ b/src/tribble/transformers/reporting_periodizer.py
@@ -1,5 +1,6 @@
 import datetime
 import pandas as pd
+import numpy as np
 from tribble.transformers import base
 
 
@@ -8,31 +9,34 @@ class ReportingPeriodizer(base.BaseTransform):
     MAX_DATE = datetime.date(9999, 12, 31)
 
     @staticmethod
-    def _period_ends(row: pd.Series) -> pd.Series:
-        if row['next_source_fiscal'] and not pd.isnull(row['next_source_fiscal']):
-            day_before_next_fiscal = row['next_source_fiscal'] - datetime.timedelta(days=1)
-            end = min(row['contract_period_end'], day_before_next_fiscal)
-        else:
-            end = row['contract_period_end']
-        row['reporting_period_end'] = end
-        return row
+    def _least(left, right):
+        return np.where(left <= right, left, right)
+
+    @staticmethod
+    def _greatest(left, right):
+        return np.where(left >= right, left, right)
 
     @classmethod
-    def _period_starts(cls, row: pd.Series) -> pd.Series:
-        if row['last_contract_period_end']  and not pd.isnull(row['last_contract_period_end']):
-            day_after_last_end = row['last_contract_period_end'] + datetime.timedelta(days=1)
-            start = min(row['source_fiscal'] or cls.MAX_DATE, day_after_last_end)
-        else:
-            start = min(row['contract_period_start'], row['source_fiscal'] or cls.MAX_DATE)
-        row['reporting_period_start'] = start
-        return row
+    def _period_starts(cls,
+                       source_fiscal: pd.Series,
+                       contract_period_start: pd.Series,
+                       contract_period_end: pd.Series) -> pd.Series:
+        prior_contract_period_end = contract_period_end.shift(1)
+
+        return np.where(pd.isnull(prior_contract_period_end),
+                        contract_period_start,
+                        cls._greatest(source_fiscal, contract_period_start))
+
+    @classmethod
+    def _period_ends(cls, period_start: pd.Series, contract_period_end: pd.Series) -> pd.Series:
+        next_period_start = period_start.shift(-1)
+
+        return np.where(pd.isnull(next_period_start),
+                        contract_period_end,
+                        next_period_start - datetime.timedelta(days=1))
 
     def apply(self, data: pd.DataFrame) -> pd.DataFrame:
-        data['next_source_fiscal'] = data['source_fiscal'].shift(-1)
-        data['last_contract_period_end'] = data['contract_period_end'].shift(1)
-
-        data = data.apply(self._period_ends, reduce=False, axis=1) \
-            .apply(self._period_starts, reduce=False, axis=1)
-        del data['next_source_fiscal']
-        del data['last_contract_period_end']
+        data = data.sort_values('source_fiscal')
+        data['reporting_period_start'] = self._period_starts(data['source_fiscal'], data['contract_period_start'], data['contract_period_end'])
+        data['reporting_period_end'] = self._period_ends(data['reporting_period_start'], data['contract_period_end'])
         return data

--- a/src/tribble/transformers/reporting_periodizer.py
+++ b/src/tribble/transformers/reporting_periodizer.py
@@ -37,6 +37,8 @@ class ReportingPeriodizer(base.BaseTransform):
 
     def apply(self, data: pd.DataFrame) -> pd.DataFrame:
         data = data.sort_values('source_fiscal')
-        data['reporting_period_start'] = self._period_starts(data['source_fiscal'], data['contract_period_start'], data['contract_period_end'])
+        data['reporting_period_start'] = self._period_starts(data['source_fiscal'],
+                                                             data['contract_period_start'],
+                                                             data['contract_period_end'])
         data['reporting_period_end'] = self._period_ends(data['reporting_period_start'], data['contract_period_end'])
         return data

--- a/src/tribble/transformers/reporting_periodizer.py
+++ b/src/tribble/transformers/reporting_periodizer.py
@@ -28,11 +28,11 @@ class ReportingPeriodizer(base.BaseTransform):
         return row
 
     def apply(self, data: pd.DataFrame) -> pd.DataFrame:
-        data = data.sort_values(['uuid', 'contract_period_start', 'source_fiscal'])
-        grouped_data = data.groupby('uuid', sort=False)
-        data['next_source_fiscal'] = grouped_data['source_fiscal'].shift(-1)
-        data['last_contract_period_end'] = grouped_data['contract_period_end'].shift(1)
+        data['next_source_fiscal'] = data['source_fiscal'].shift(-1)
+        data['last_contract_period_end'] = data['contract_period_end'].shift(1)
 
-        return data.apply(self._period_ends, reduce=False, axis=1) \
-            .apply(self._period_starts, reduce=False, axis=1) \
-            .drop(['next_source_fiscal', 'last_contract_period_end'], axis=1)
+        data = data.apply(self._period_ends, reduce=False, axis=1) \
+            .apply(self._period_starts, reduce=False, axis=1)
+        del data['next_source_fiscal']
+        del data['last_contract_period_end']
+        return data

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,11 +1,35 @@
 import datetime
 import typing
 import pandas
+import pytest
 from tribble import transform
 
 
-def data_template(overrides: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
-    data = {
+class DataTemplate:
+
+    def __init__(self, default: typing.Dict[str, typing.Any]) -> None:
+        self._default = default
+
+    def _generate_rows(self, overrides: typing.List[typing.Dict[str, typing.Any]]
+                       ) -> typing.Iterable[typing.Dict[str, typing.Any]]:
+        for row in overrides:
+            assert set(row.keys()).intersection(set(self._default.keys())) == set(row.keys())
+
+            generated_row = self._default.copy()
+            generated_row.update(row)
+            yield generated_row
+
+    def to_df(self, overrides: typing.List[typing.Dict[str, typing.Any]]) -> pandas.DataFrame:
+        return pandas.DataFrame(self._generate_rows(overrides))
+
+    def to_dicts(self, overrides: typing.List[typing.Dict[str, typing.Any]]
+                 ) -> typing.List[typing.Dict[str, typing.Any]]:
+        return list(self._generate_rows(overrides))
+
+
+@pytest.fixture
+def input_template() -> DataTemplate:
+    return DataTemplate({
         "uuid": "tbs-0000000000",
         "vendorName": "ABC Company",
         "referenceNumber": "0000000000",
@@ -34,13 +58,12 @@ def data_template(overrides: typing.Dict[str, typing.Any]) -> typing.Dict[str, t
         "yearsDuration": 6,
         "valuePerYear": 1000.0,
         "vendorClean": "Big Contract #1"
-    }
-    data.update(overrides)
-    return data
+    })
 
 
-def output_template(overrides: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
-    data = {
+@pytest.fixture
+def output_template() -> DataTemplate:
+    return DataTemplate({
         "uuid": "tbs-0000000000",
         "vendor_name": "ABC Company",
         "reference_number": "0000000000",
@@ -53,31 +76,64 @@ def output_template(overrides: typing.Dict[str, typing.Any]) -> typing.Dict[str,
         "department": "tbs",
         "source_fiscal": datetime.date(2013, 1, 1),
         "object_code": "0499"
-    }
-    data.update(overrides)
-    return data
+    })
 
 
-def test_transform() -> None:
-    data = pandas.DataFrame([data_template({})])
+def test_transform(input_template: DataTemplate, output_template: DataTemplate) -> None:
+    data = input_template.to_df([{}])
     output = transform.transform(data).to_dict('records')
+    expected = output_template.to_dicts([{}])
+    assert output == expected
 
-    assert output == [output_template({})]
 
-
-def test_bad_contract_dates() -> None:
-    data = data_template({
+def test_bad_contract_dates(input_template: DataTemplate, output_template: DataTemplate) -> None:
+    data = input_template.to_df([{
         'contractDate': '2012-10-10',
         'contractPeriodStart': '0001-01-01',
         'contractPeriodEnd': '1899-12-31',
-    })
-    df = pandas.DataFrame([data])
+    }])
 
-    expected = output_template({
+    expected = output_template.to_dicts([{
         'contract_date': datetime.date(2012, 10, 10),
         'contract_period_start': datetime.date(2012, 10, 10),
         'contract_period_end': datetime.date(2012, 10, 10),
         'reporting_period_start': datetime.date(2012, 10, 10),
         'reporting_period_end': datetime.date(2012, 10, 10),
-    })
-    assert transform.transform(df).to_dict('records') == [expected]
+    }])
+    assert transform.transform(data).to_dict('records') == expected
+
+
+def test_contract_starts_that_go_backwards_in_time(input_template: DataTemplate, output_template: DataTemplate) -> None:
+    data = input_template.to_df([
+        {
+            'contractDate': '2012-01-01',
+            'contractPeriodStart': '2011-12-01',
+            'contractPeriodEnd': '2014-01-01',
+            'sourceFiscal': '2013-01-01',
+        }, {
+            'contractDate': '2013-01-01',
+            'contractPeriodStart': '2010-01-01',
+            'contractPeriodEnd': '2015-01-01',
+            'sourceFiscal': '2013-04-01',
+        }
+    ])
+    output = transform.transform(data).to_dict('records')
+    output = sorted(output, key=lambda r: r['contract_date'])
+
+    expected = output_template.to_dicts([
+        {
+            'contract_date': datetime.date(2012, 1, 1),
+            'contract_period_start': datetime.date(2010, 1, 1),
+            'contract_period_end': datetime.date(2014, 1, 1),
+            'reporting_period_start': datetime.date(2010, 1, 1),
+            'reporting_period_end': datetime.date(2014, 1, 1),
+        }, {
+            'contract_date': datetime.date(2013, 1, 1),
+            'contract_period_start': datetime.date(2010, 1, 1),
+            'contract_period_end': datetime.date(2015, 1, 1),
+            'reporting_period_start': datetime.date(2014, 1, 1),
+            'reporting_period_end': datetime.date(2015, 1, 1),
+        }
+    ])
+    assert output == expected
+

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -86,6 +86,38 @@ def test_transform(input_template: DataTemplate, output_template: DataTemplate) 
     assert output == expected
 
 
+def test_fiscal_date_converter(input_template: DataTemplate, output_template: DataTemplate) -> None:
+    data = input_template.to_df([
+        {'uuid': '1', 'sourceFiscal': '201213-Q1'},
+        {'uuid': '2', 'sourceFiscal': '201213-Q2'},
+        {'uuid': '3', 'sourceFiscal': '201213-Q3'},
+        {'uuid': '4', 'sourceFiscal': '201213-Q4'},
+    ])
+    output = transform.transform(data).to_dict('records')
+    expected = output_template.to_dicts([
+        {'uuid': '1', 'source_fiscal': datetime.date(2012, 4, 1), 'reporting_period_end': None},
+        {'uuid': '2', 'source_fiscal': datetime.date(2012, 7, 1), 'reporting_period_end': None},
+        {'uuid': '3', 'source_fiscal': datetime.date(2012, 10, 1), 'reporting_period_end': None},
+        {'uuid': '4', 'source_fiscal': datetime.date(2013, 1, 1), 'reporting_period_end': None},
+    ])
+    assert output == expected
+
+
+def test_fiscal_date_converting_bad_data(input_template: DataTemplate, output_template: DataTemplate) -> None:
+    data = input_template.to_df([
+        {'sourceFiscal': '2012-04-01'},
+        {'sourceFiscal': '201213'},
+        {'sourceFiscal': '201213-Q5'},
+    ])
+    output = transform.transform(data).to_dict('records')
+    expected = output_template.to_dicts([
+        {'source_fiscal': None},
+        {'source_fiscal': None},
+        {'source_fiscal': None},
+    ])
+    assert output == expected
+
+
 def test_bad_contract_dates(input_template: DataTemplate, output_template: DataTemplate) -> None:
     data = input_template.to_df([{
         'contractDate': '2012-10-10',
@@ -136,4 +168,3 @@ def test_contract_starts_that_go_backwards_in_time(input_template: DataTemplate,
         }
     ])
     assert output == expected
-


### PR DESCRIPTION
Some test refactoring to use the `DataTemplate` approach. Added a failing test to correct for contracts which later versions claim an earlier start date.

The conservative approach would be to use the minimum `contract_period_start` for each reference number. `contract_period_end` can go later over time.