### PR TITLE
Fix small things in README: MySQL link, virtualenv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ Processing GoC-Spending data output
 ## Requirements
 
 - Python 3.6
-- [MySQL](https://dev.mysql.com/downloads/cluster/)
+- [MySQL](hhttps://dev.mysql.com/downloads/mysql/)
 
 ## Installation
 
 - Create a python virtual environment
   - `python -m venv env`
-  - `source env/bin/activate`
-- Install requirements
+- Install required python packages
   - `pip install -r requirements.txt`
   - `pip install -e .` 
 
 ## Usage
 
+- `source env/bin/activate` (run each time you open the repo in a shell, to activate the virtual environment)
 - `tribble --help`


### PR DESCRIPTION
Fixes two small issues noted in #19:

* Changes MySQL link to reference the community edition.
* Moves the virtualenv activation to the usage section with an explanatory note.