### PR TITLE
temporarily disabling false positive linter errors

### DIFF
--- a/src/tribble/cli.py
+++ b/src/tribble/cli.py
@@ -22,7 +22,7 @@ def main(ctx: click.core.Context, host: str, user: str, password: typing.Optiona
 
     Type --help after any subcommand for additional help."""
     ctx.obj = {}
-    creds = tribble.database.Creds(host, user, password, schema)
+    creds = tribble.database.Creds(host, user, password, schema)  # pylint: disable=too-many-function-args
     engine = tribble.database.connect_db(creds)
     contract.Session.configure(bind=engine)
     ctx.obj['creds'] = creds
@@ -39,7 +39,7 @@ def create_db(ctx: click.core.Context, runtime_user: str, runtime_host: str, for
 
     Needs to be run with admin privileges, e.g. `tribble --user root create_db`"""
     passed_creds = ctx.obj['creds']
-    creds = tribble.database.Creds(host=passed_creds.host, user=passed_creds.user,
+    creds = tribble.database.Creds(host=passed_creds.host, user=passed_creds.user,  # pylint: disable=no-value-for-parameter
                                    password=passed_creds.password, database='mysql')
     engine = tribble.database.connect_db(creds)
     tribble.database.create_db(engine, passed_creds.database, runtime_user, runtime_host, force)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def db_name(db_host: str, db_user: str) -> typing.Iterable[str]:
     admin_user = os.environ.get('TRIBBLE_DB_ADMIN_USER', 'root')
     admin_password = os.environ.get('TRIBBLE_DB_ADMIN_PASSWORD')
 
-    creds = database.Creds(host=db_host, user=admin_user, password=admin_password, database='mysql')
+    creds = database.Creds(host=db_host, user=admin_user, password=admin_password, database='mysql')  # pylint: disable=no-value-for-parameter
     engine = database.connect_db(creds)
 
     connection = engine.connect()
@@ -58,7 +58,7 @@ def db_name(db_host: str, db_user: str) -> typing.Iterable[str]:
 
 @pytest.fixture
 def db_engine(db_host: str, db_user: str, db_password: str, db_name: str) -> engine.base.Engine:
-    creds = database.Creds(host=db_host, user=db_user, password=db_password, database=db_name)
+    creds = database.Creds(host=db_host, user=db_user, password=db_password, database=db_name)  # pylint: disable=no-value-for-parameter
     eng = database.connect_db(creds)
     contract.Session.configure(bind=eng)
     return eng


### PR DESCRIPTION
Something has caused `typing.NamedTuple` instances to no longer be linted correctly on the master image. This PR temporarily disables the specific failures on master to allow others to move forward.

I can't reproduce the error locally, but I will continue to investigate.