### PR TITLE
update dockerignore, push to dockerhub on success

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,6 @@
 .idea
 .mypy_cache
 env
+**/*.pyc
+**/__pycache__
+**/*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,9 @@ script:
   - docker run jasonmwhite/tribble script/run_tests.sh
   - docker run jasonmwhite/tribble pylint src tests
   - docker run jasonmwhite/tribble mypy src tests
+
+after_success:
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
+    docker push yowct/fuzzy-tribble;
+    fi


### PR DESCRIPTION
Two  improvements:
- don't include python cache artifacts in the built docker image
- on success on master branch, push to dockerhub