### PR TITLE
fix docker tag name and build from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ services:
   - docker
 
 install:
-  - docker build -t jasonmwhite/tribble .
+  - docker pull yowct/fuzzy-tribble || true
+  - docker build --cache-from yowct/fuzzy-tribble --tag yowct/fuzzy-tribble .
 
 script:
-  - docker run jasonmwhite/tribble script/run_tests.sh
-  - docker run jasonmwhite/tribble pylint src tests
-  - docker run jasonmwhite/tribble mypy src tests
+  - docker run yowct/fuzzy-tribble script/run_tests.sh
+  - docker run yowct/fuzzy-tribble pylint src tests
+  - docker run yowct/fuzzy-tribble mypy src tests
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then


### PR DESCRIPTION
I forgot to update all of the image names from `jasonmwhite/tribble` to `yowct/fuzzy-tribble`. This should fix that.