### PR TITLE
bump mypy to 0.560

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ lxml==4.0.0
 requests==2.18.4
 pandas==0.20.3
 pylint==1.7.3
-mypy==0.521
+mypy==0.560
 pytest==3.2.2
 sqlalchemy==1.1.14
 mysqlclient==1.3.12


### PR DESCRIPTION
Bumping mypy to 0.560. Mainly as an excuse to double-check the docker caching.