### PR TITLE
downgrade astroid to 1.5.3 to remove NamedTuple false positives

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click==6.7
 lxml==4.0.0
 requests==2.18.4
 pandas==0.20.3
+astroid==1.5.3
 pylint==1.7.3
 mypy==0.560
 pytest==3.2.2

--- a/src/tribble/cli.py
+++ b/src/tribble/cli.py
@@ -24,7 +24,7 @@ def main(ctx: click.core.Context, host: str, user: str, password: typing.Optiona
 
     Type --help after any subcommand for additional help."""
     ctx.obj = {}
-    creds = tribble.database.Creds(host, user, password, schema)  # pylint: disable=too-many-function-args
+    creds = tribble.database.Creds(host, user, password, schema)
     engine = tribble.database.connect_db(creds)
     contract.Session.configure(bind=engine)
     ctx.obj['creds'] = creds
@@ -41,7 +41,7 @@ def create_db(ctx: click.core.Context, runtime_user: str, runtime_host: str, for
 
     Needs to be run with admin privileges, e.g. `tribble --user root create_db`"""
     passed_creds = ctx.obj['creds']
-    creds = tribble.database.Creds(host=passed_creds.host, user=passed_creds.user,  # pylint: disable=no-value-for-parameter
+    creds = tribble.database.Creds(host=passed_creds.host, user=passed_creds.user,
                                    password=passed_creds.password, database='mysql')
     engine = tribble.database.connect_db(creds)
     tribble.database.create_db(engine, passed_creds.database, runtime_user, runtime_host, force)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def db_name(db_host: str, db_user: str) -> typing.Iterable[str]:
     admin_user = os.environ.get('TRIBBLE_DB_ADMIN_USER', 'root')
     admin_password = os.environ.get('TRIBBLE_DB_ADMIN_PASSWORD')
 
-    creds = database.Creds(host=db_host, user=admin_user, password=admin_password, database='mysql')  # pylint: disable=no-value-for-parameter
+    creds = database.Creds(host=db_host, user=admin_user, password=admin_password, database='mysql')
 
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', ".*\'@@tx_isolation\' is deprecated.*")
@@ -63,7 +63,7 @@ def db_name(db_host: str, db_user: str) -> typing.Iterable[str]:
 
 @pytest.fixture
 def db_engine(db_host: str, db_user: str, db_password: str, db_name: str) -> engine.base.Engine:
-    creds = database.Creds(host=db_host, user=db_user, password=db_password, database=db_name)  # pylint: disable=no-value-for-parameter
+    creds = database.Creds(host=db_host, user=db_user, password=db_password, database=db_name)
     eng = database.connect_db(creds)
     contract.Session.configure(bind=eng)
     return eng


### PR DESCRIPTION
Looks like there's an issue with Astroid 1.6.0 and pylint, where it no longer correctly lints instances of `typing.NamedTuple`. Downgrading to 1.5.3 solves it for now.