### PR TITLE
Ensuring that tribble load works with one-level nested dirs

### DIFF
--- a/src/tribble/reader.py
+++ b/src/tribble/reader.py
@@ -1,15 +1,15 @@
 import itertools
 import json
-import os
 import typing
 import pandas as pd
+import glob
 
 
 T = typing.TypeVar('T')
 
 
 def _json_blobs(input_dir: str) -> typing.Iterator[typing.Dict[str, typing.Any]]:
-    input_filenames = [os.path.join(input_dir, dir_name) for dir_name in os.listdir(input_dir)]
+    input_filenames = glob.glob(input_dir + '/**/*.json', recursive=True)
 
     for filename in input_filenames:
         with open(filename) as input_file:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,13 @@ def input_dir(tmpdir: py._path.local.LocalPath) -> py._path.local.LocalPath:
 
 
 @pytest.fixture
-def data_file(input_dir: py._path.local.LocalPath) -> str:
-    data_file = input_dir.join('data.json')
+def input_sub_dir(input_dir: py._path.local.LocalPath) -> py._path.local.LocalPath:
+    return input_dir.mkdir('sub')
+
+
+@pytest.fixture
+def data_file(input_sub_dir: py._path.local.LocalPath) -> str:
+    data_file = input_sub_dir.join('data.json')
     data_file.write(json.dumps({
         "uuid": "tbs-0000000000",
         "vendorName": "ABC Company",
@@ -49,7 +54,24 @@ def data_file(input_dir: py._path.local.LocalPath) -> str:
 
 
 @pytest.mark.usefixtures('db', 'data_file')
-def test_load(input_dir: py._path.local.LocalPath) -> None:
+def test_load(input_sub_dir: py._path.local.LocalPath) -> None:
+    runner = click.testing.CliRunner()  # type: ignore
+    result = runner.invoke(cli.load, [str(input_sub_dir)])
+    assert result.exit_code == 0
+
+    session = contract.Session()
+    contracts = list(session.query(contract.Contract))
+    raw_contracts = list(session.query(contract.Contract))
+    session.close()
+
+    assert len(contracts) == 1
+    assert contracts[0].uuid == 'tbs-0000000000'
+    assert len(raw_contracts) == 1
+    assert raw_contracts[0].uuid == 'tbs-0000000000'
+
+
+@pytest.mark.usefixtures('db', 'data_file')
+def test_load_with_subfolders(input_dir: py._path.local.LocalPath) -> None:
     runner = click.testing.CliRunner()  # type: ignore
     result = runner.invoke(cli.load, [str(input_dir)])
     assert result.exit_code == 0
@@ -63,7 +85,6 @@ def test_load(input_dir: py._path.local.LocalPath) -> None:
     assert contracts[0].uuid == 'tbs-0000000000'
     assert len(raw_contracts) == 1
     assert raw_contracts[0].uuid == 'tbs-0000000000'
-
 
 def test_init_db(db_engine: engine.base.Engine) -> None:
     connection = db_engine.connect()


### PR DESCRIPTION
For issue #27:
Seems like this issue should actually be - change tribble load to handle nested directories?

Tested locally. Can put in a unit test if needed