### PR TITLE
contracts can't end before they start

### DIFF
--- a/src/tribble/transformers/contract_date_cleaner.py
+++ b/src/tribble/transformers/contract_date_cleaner.py
@@ -41,8 +41,14 @@ class ContractDateCleaner(base.BaseTransform):
 
         return row
 
+    @staticmethod
+    def _end_not_before_start(row: pd.Series) -> pd.Series:
+        row['contract_period_end'] = max(row['contract_period_end'], row['contract_period_start'])
+        return row
+
     def apply(self, data: pd.DataFrame) -> pd.DataFrame:
         cleaned = data.apply(self._set_null_contract_dates, reduce=False, axis=1) \
             .apply(self._clear_invalid_dates, reduce=False, axis=1) \
-            .apply(self._clean_row, reduce=False, axis=1)
+            .apply(self._clean_row, reduce=False, axis=1) \
+            .apply(self._end_not_before_start, reduce=False, axis=1)
         return cleaned.drop(['delivery_date'], axis=1)

--- a/tests/transformers/test_contract_date_cleaner.py
+++ b/tests/transformers/test_contract_date_cleaner.py
@@ -93,3 +93,19 @@ def test_contract_date_and_contract_period_end(template: typing.Dict) -> None:
         'contract_period_end': datetime.date(2017, 3, 15),
         'source_fiscal': datetime.date(2017, 1, 1),
     }]
+
+
+def test_contract_end_before_start(template: typing.Dict) -> None:
+    template.update({
+        'contract_date': datetime.date(2017, 4, 16),
+        'contract_period_end': datetime.date(2017, 4, 15),
+        'contract_period_start': datetime.date(2017, 4, 16),
+    })
+    data = pd.DataFrame([template])
+    output = contract_date_cleaner.ContractDateCleaner().apply(data)
+    assert output.to_dict('records') == [{
+        'contract_date': datetime.date(2017, 4, 16),
+        'contract_period_start': datetime.date(2017, 4, 16),
+        'contract_period_end': datetime.date(2017, 4, 16),
+        'source_fiscal': datetime.date(2017, 1, 1),
+    }]


### PR DESCRIPTION
If a contract end date is before the listed start date, assume the end date is the same as the start date.